### PR TITLE
Used old logic for outdated

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,6 @@ function cpclean (item) {
 }
 
 cpclean('registry')
-cpclean('registry-update')
 
 shop.cpr = cpr
 function cpr (from, to) {

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -10,7 +10,6 @@ var util = require('util')
 
 var pidfile = path.resolve(shop.datadir, 'registry.pid')
 var assetdir = path.resolve(shop.datadir, 'registry')
-var assetdirUpdated = path.resolve(shop.datadir, 'registry-update')
 
 var logStream = fs.createWriteStream(path.resolve(shop.datadir, 'registry.log'), {flags: 'a'})
 function log () {
@@ -73,8 +72,8 @@ function handler (args) {
     req.url = unescape(req.url)
     log('%s %s %s', lesson, req.method, req.url)
 
-    var staticDir = assetdir
     switch (lesson) {
+      case 'outdated':
       case 'install-a-module':
         // Just the default static handling
         break
@@ -98,13 +97,9 @@ function handler (args) {
           return handleDistTags(parsed, req, res)
         }
         break
-
-      case 'outdated':
-        staticDir = assetdirUpdated
-        break
     }
 
-    staticFiles(staticDir, req, res)
+    staticFiles(assetdir, req, res)
   }
 }
 

--- a/problems/13-outdated/index.js
+++ b/problems/13-outdated/index.js
@@ -8,6 +8,13 @@ exports.problem = {
 
 exports.init = function (workshopper) {
   this.__ = workshopper.i18n.__
+  var pkg = require(shop.datadir + '/registry/@linclark/pkg/body.json')
+  if (pkg['dist-tags'].latest === '1.0.2') {
+    // publish an update
+    console.log(path.resolve(__dirname, '..', '..', 'assets', 'registry-update'))
+    shop.cpr(path.resolve(__dirname, '..', '..', 'assets', 'registry-update'),
+             path.resolve(shop.datadir, 'registry'))
+  }
   reg.run('outdated')
 }
 


### PR DESCRIPTION
In an attempt to fix outdated I used the short-sighted logic of simply using another registry. The solution of master (to simply copy the necessary part to the registry) is better. This reverts the former logic and uses the old one.

The reason why the "other registry" approach is problematic is: The user had to publish packages to the registry and they are stored in `{shop.appdir}/registry` and if we switch the user can't verify that anymore.